### PR TITLE
Make access to the validator app sequential

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ ledger = "0.0.9"
 quick-error = "1.2.2"
 byteorder = "1.2.4"
 matches = "0.1.8"
+lazy_static = "1.2.0"
 
 [dev-dependencies]
 ed25519-dalek = "0.8.1"


### PR DESCRIPTION
Previously the tests passed individually, but not when all run together.
This was due to every test connecting to the Ledger application. This
commit makes the Ledger application a global variable that is protected
by a mutex so that it can be shared between tests.

closes #1